### PR TITLE
Integrated libpreopen with capsh, added blind arg preopening mechanism

### DIFF
--- a/src/platform/FreeBSD.hh
+++ b/src/platform/FreeBSD.hh
@@ -37,6 +37,8 @@
 #include <unordered_map>
 #include <vector>
 
+struct po_map;
+
 namespace capsh {
 
 class FreeBSD : public Capsicum
@@ -60,6 +62,7 @@ private:
 	const LinkerMap linkers_;
 	const std::vector<int> libdirs_;
 	const std::vector<int> pathdirs_;
+	po_map *map;
 };
 
 } // namespace capsh


### PR DESCRIPTION
A blind argument preopening mechanism has been added to platform/FreeBSD.cc which checks all the arguments(excluding the first and the flags) and preopens them with the help of libpreopen.

Libpreopen has been integrated into capsh, well enough so that a po_map is created, all the arguments are preopened and the corresponding po_map_entry's are added to the po_map and the po_map is packed into the shared memory, and the shared memory file descriptor is loaded on the environment variable SHARED_MEMORYFD, while passing the close-on-exec flag as 0.

Hence, cat works!